### PR TITLE
ガンベル分布証明

### DIFF
--- a/1_model.tex
+++ b/1_model.tex
@@ -68,11 +68,18 @@ $U_S,U_B,U_P$ が正規分布に従う場合、この確率を計算するのは
 
 正規分布に形状が似ていて、離散選択モデルの計算上都合がいい性質を持っている分布として、\textbf{ガンベル分布}が用いられます。効用がガンベル分布に従うと仮定したモデルのことを\textbf{ロジットモデル}と呼びます。
 
-ガンベル分布の確率密度関数は式(\ref{eq:gumbel_pdf})の通りです。
+ガンベル分布の確率密度関数 $f(x)$ は式(\ref{eq:gumbel_pdf})の通りです。
 
 \begin{equation}
     \label{eq:gumbel_pdf}
     f(x) = \mu \exp(-\mu (x-\eta)) \exp(-\exp(-\mu (x-\eta)))
+\end{equation}
+
+また、累積密度関数は式(\ref{eq:gumbel_cdf})の通りです。
+
+\begin{equation}
+    \label{eq:gumbel_cdf}
+    F(x) = \exp(-\exp(-\mu (x-\eta)))
 \end{equation}
 
 ここで、$\mu$ はガンベル分布の\textbf{スケールパラメータ}、$\eta$ は\textbf{ロケーションパラメータ}と呼ばれます。正規分布において平均値 $\mu$ と分散 $\sigma^2$ が与えられれば分布の形状が分かるのと同様に、ガンベル分布においてスケールパラメータとロケーションパラメータが分かれば分布の形状が分かります。
@@ -90,19 +97,24 @@ $U_S,U_B,U_P$ が正規分布に従う場合、この確率を計算するのは
         \label{eq:gumbel_max}
         \left(\frac{1}{\mu} \ln\sum_{i=1}^N \exp(\mu\eta_i), \mu\right)
     \end{equation}
+
+    ※ロケーションパラメータは変数ごとに異なっていてもよいですが、\textbf{スケールパラメータは同じ}である必要があります。
 \end{theorem}
+\begin{proof}
+    \ref{prf:gumbel_max}を参照。
+\end{proof}
 
 \begin{theorem}
-
     \label{it:logistic}
     独立な二つの確率変数 $X_1,X_2$ がそれぞれガンベル分布 $Gb(\eta_1, \mu), Gb(\eta_2, \mu)$ に従うとき、その差 $X_1-X_2$ は、式(\ref{eq:logistic})に示す累積分布関数を持つ\textbf{ロジスティック分布}に従う。
     \begin{equation}
         \label{eq:logistic}
-        F(x)=\frac{1}{1+\exp(\mu(\eta_2-\eta_1-x))}
+        F(x)=\frac{1}{1+\exp(\mu(\eta_1-\eta_2-x))}
     \end{equation}
-
-    ※ロケーションパラメータは変数ごとに異なっていてもよいですが、\textbf{スケールパラメータは同じ}である必要があります。
 \end{theorem}
+\begin{proof}
+    \ref{prf:logistic}を参照。
+\end{proof}
 
 この二つの性質を用いることで、積分計算なしに選択確率を計算することができます。
 

--- a/a_appendix.tex
+++ b/a_appendix.tex
@@ -1,0 +1,56 @@
+\chapter{Appendix}
+\section{定理 \ref{it:gumbel_max} の証明}
+
+\begin{proof}
+    \label{prf:gumbel_max}
+    \begin{equation}
+        \begin{aligned}
+              & P(\max(X_1,X_2, \ldots X_i, \ldots, X_N) \le x)                                                                                              \\
+            = & \prod_{i=1}^N P(X_i \le x)                                                                                                                   \\
+            = & \prod_{i=1}^N \left(\exp(-\exp(-\mu(x-\eta_i)))\right)                                            & (\because 累積密度関数(式 \ref{eq:gumbel_cdf})) \\
+            = & \exp\left(-\sum_{i=1}^N\exp(-\mu(x-\eta_i))\right)                                                                                           \\
+            = & \exp\left(-\exp\left(-\mu\left(x-\frac{1}{\mu}\ln\sum_{i=1}^N\exp(\mu\eta_i)\right)\right)\right)
+        \end{aligned}
+    \end{equation}
+    これは $Gb\left(\frac{1}{\mu} \ln\sum_{i=1}^N \exp(\mu\eta_i), \mu\right)$ の累積密度関数である。
+\end{proof}
+
+\section{定理 \ref{it:logistic} の証明}
+\begin{proof}
+    \label{prf:logistic}
+    \begin{equation}
+        \begin{aligned}
+              & P(X_1-X_2 \le x)                                                                                              \\
+            = & P(X_1 \le x+X_2)                                                                                              \\
+            = & \int_{-\infty}^{\infty} P(X_1 \le x+X_2|X_2=y)f_{X_2}(y)dy                                                    \\
+            = & \int_{-\infty}^{\infty} P(X_1 \le x+y)f_{X_2}(y)dy                                                            \\
+            = & \int_{-\infty}^{\infty} \exp(-\exp(-\mu(x+y-\eta_1)))f_{X_2}(y)dy                                             \\
+            = & \int_{-\infty}^{\infty} \exp(-\exp(-\mu(x+y-\eta_1)))\mu \exp(-\mu (y-\eta_2)) \exp(-\exp(-\mu (y-\eta_2)))dy \\
+        \end{aligned}
+    \end{equation}
+    ここで、変数変換 $z = \exp(-\mu (y-\eta_2))$ を行うと、$dz = -\mu\exp(-\mu (y-\eta_2))dy$。また積分区間は下表\ref{tbl:int_interval}のとおり。
+
+    \begin{table}[ht]
+        \caption{$x \to z$ の積分区間}
+        \centering
+        \label{tbl:int_interval}
+        \begin{tabular}{ccc}
+            \hline
+            $y$ & $-\infty$ & $\infty$ \\
+            \hline
+            $z$ & $\infty$  & 0        \\
+            \hline
+        \end{tabular}
+    \end{table}
+
+    \begin{equation}
+        \begin{aligned}
+              & \int_{-\infty}^{\infty} \exp(-\exp(-\mu(x+y-\eta_1)))\mu \exp(-\mu (y-\eta_2)) \exp(-\exp(-\mu (y-\eta_2)))dy               \\
+            = & \int_{-\infty}^{\infty} \exp(-\exp(-\mu(y-\eta_2+x-\eta_1+\eta_2)))\mu \exp(-\mu (y-\eta_2)) \exp(-\exp(-\mu (y-\eta_2)))dy \\
+            = & \int_{0}^{\infty} \exp(-z\exp(\mu(\eta_1-\eta_2-x))) \exp(-z)dz                                                             \\
+            = & \int_{0}^{\infty} \exp(-z(1+\exp(\mu(\eta_1-\eta_2-x))))dz                                                                  \\
+            = & \left[-\frac{1}{1+\exp(\mu(\eta_1-\eta_2-x))} \exp(-z(1+\exp(\mu(\eta_1-\eta_2-x))))\right]_{z=0}^{z \to\infty}             \\
+            = & \frac{1}{1+\exp(\mu(\eta_1-\eta_2-x))}
+        \end{aligned}
+    \end{equation}
+\end{proof}

--- a/main.tex
+++ b/main.tex
@@ -52,7 +52,7 @@
 \title{{\huge 離散選択モデル入門}\\{\large Introduction to Discrete Choice Models} \\ 
 $\,$\\$\,$\\$\,$\\$\,$\\$\,$\\$\,$\\$\,$\\}
 \author{林~由翔\\Yuito Hayashi}
-\date{2022年2月 作成 \\ 2024年4月 最終更新}
+\date{2022年2月 作成 \\ 2024年9月 最終更新}
 \begin{document}
 
 \maketitle
@@ -76,6 +76,8 @@ $\,$\\$\,$\\$\,$\\$\,$\\$\,$\\$\,$\\$\,$\\}
 \input{3_parameter_est}
 \input{4_testing}
 \input{5_code}
+\appendix
+\input{a_appendix}
 
 \backmatter
 \bibliographystyle{plainnat}


### PR DESCRIPTION
ちなみに科研本に誤植を見つけた。

$$\varepsilon_1$$ と $$\varepsilon_2$$ がパラメータ $$(\eta_1, \mu),(\eta_2, \mu)$$ のガンベル分布に従うとき、 $$\varepsilon = \varepsilon_1 - \varepsilon_2$$ は次の累積密度関数を持つロジスティック分布に従う。

誤:

$$F(\varepsilon)=\frac{1}{1+\exp(\mu(\eta_2-\eta_1-\varepsilon))}$$

正:

$$F(\varepsilon)=\frac{1}{1+\exp(\mu(\eta_1-\eta_2-\varepsilon))}$$

この後の議論では $$\eta_1=\eta_2=0$$ であるので後続の証明には影響しない。